### PR TITLE
Do not use git to get tests into 1minutetip

### DIFF
--- a/1minutetip/Makefile
+++ b/1minutetip/Makefile
@@ -29,7 +29,7 @@ export TESTVERSION=1.0
 
 BUILT_FILES=
 
-FILES=$(METADATA) runtest.sh Makefile
+FILES=$(METADATA) runtest.sh Makefile db-ci-tests
 
 .PHONY: all install download clean
 

--- a/1minutetip/run1minutetip.sh
+++ b/1minutetip/run1minutetip.sh
@@ -9,6 +9,11 @@ fi
 
 test_dir=$(mktemp -d "/var/tmp/test-db-XXXXXX")
 
+
+mkdir ${test_dir}/db-ci-tests
+tar cfz ${test_dir}/db-ci-tests/db-ci-tests.tar.gz \
+    "$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/..)"
+
 cat >${test_dir}/run1minutetip.sh <<EOF
 PACKAGES="koji createrepo git wget vim"
 1minutetip -p "PACKAGES=\"\${PACKAGES}\"" 1MT-Fedora24
@@ -19,9 +24,12 @@ cat >${test_dir}/runtest.sh <<EOF
 set -x
 echo PASS >/tmp/1minutetip.result
 
-yum -y install koji createrepo git wget vim
+yum -y install koji createrepo wget vim
 
-git clone https://github.com/hhorak/db-ci-tests.git
+pushd db-ci-tests
+tar xfz db-ci-tests.tar.gz
+popd
+
 EOF
 
 while [ -n "$1" ] ; do
@@ -36,5 +44,5 @@ done
 chmod a+x ${test_dir}/run*sh
 cp ${THISDIR}/Makefile ${test_dir}/
 
-echo "Test ready at ${test_dir}. To run it:"
+echo "Test ready at ${test_dir} . To run it:"
 eval "pushd ${test_dir} ; ./run1minutetip.sh ; popd"


### PR DESCRIPTION
When a test is run in 1minutetip, the 1mt machine gets tests
by cloning the db-ci-tests git repository. This is a bit confusing and
impractical (every change in tests has to be pushed to remote git repo
in order to work).

This patch makes run1minutetip.sh copy the db-ci-tests repository
from local machine directly to 1mt machine, without using any remote
repository.