### PR TITLE
Fix text redirect in cat command while creating test repo

### DIFF
--- a/run-nvr.sh
+++ b/run-nvr.sh
@@ -24,7 +24,7 @@ done
 createrepo_c .
 popd
 
-cat >/etc/yum.repos.d/db-ci.repo <<<EOF
+cat >/etc/yum.repos.d/db-ci.repo <<EOF
 [db-ci]
 name=db-ci
 baseurl=file://${repodir}


### PR DESCRIPTION
Im not sure about <<<, I think I saw it somewhere, but doesnt work in bash under f27