### PR TITLE
Mariadb java client upstream tests

### DIFF
--- a/packages/mariadb-java-client-common/upstream-tests/run.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Caution: This is common script that is shared by more packages.
+# If you need to do changes related to this particular collection,
+# create a copy of this file instead of symlink.
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+source ${THISDIR}/../../../common/functions.sh
+source ${THISDIR}/../include.sh
+
+${THISDIR}/../../mariadb-java-client-common/upstream-tests/upstream-tests.sh

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+yum install mariadb-java-client mariadb-java-client-tests hamcrest junit mariadb-server
+
+# command to obtain all tests in Java format
+# find org -name '*Test.java' | cut -d'.' -f1 | tr '/' '.'
+RUN_TESTS='org.mariadb.jdbc.CheckDataTest
+org.mariadb.jdbc.ExecuteBatchTest
+org.mariadb.jdbc.TransactionTest
+org.mariadb.jdbc.ServerPrepareStatementTest
+org.mariadb.jdbc.DateTest
+org.mariadb.jdbc.MariaDbCompatibilityTest
+org.mariadb.jdbc.ScrollTypeTest
+org.mariadb.jdbc.StatementTest
+org.mariadb.jdbc.LocalInfileDisableTest
+org.mariadb.jdbc.GeneratedKeysTest
+org.mariadb.jdbc.failover.SequentialFailoverTest
+org.mariadb.jdbc.failover.AuroraFailoverTest
+org.mariadb.jdbc.failover.BaseMultiHostTest
+org.mariadb.jdbc.failover.LoadBalanceFailoverTest
+org.mariadb.jdbc.failover.MonoServerFailoverTest
+org.mariadb.jdbc.failover.CancelTest
+org.mariadb.jdbc.failover.ReplicationFailoverTest
+org.mariadb.jdbc.failover.OldFailoverTest
+org.mariadb.jdbc.failover.AuroraAutoDiscoveryTest
+org.mariadb.jdbc.failover.GaleraFailoverTest
+org.mariadb.jdbc.LocalInfileInputStreamTest
+org.mariadb.jdbc.ConnectionTest
+org.mariadb.jdbc.UnicodeTest
+org.mariadb.jdbc.AllowMultiQueriesTest
+org.mariadb.jdbc.UpdateResultSetTest
+org.mariadb.jdbc.ClientPreparedStatementParsingTest
+org.mariadb.jdbc.DataTypeUnsignedTest
+org.mariadb.jdbc.ResultSetUnsupportedMethodsTest
+org.mariadb.jdbc.ResultSetTest
+org.mariadb.jdbc.DatatypeTest
+org.mariadb.jdbc.GeneratedTest
+org.mariadb.jdbc.TimeoutTest
+org.mariadb.jdbc.CancelTest
+org.mariadb.jdbc.BaseTest
+org.mariadb.jdbc.GiganticLoadDataInfileTest
+org.mariadb.jdbc.DataSourcePoolTest
+org.mariadb.jdbc.MariaDbClobTest
+org.mariadb.jdbc.CallStatementTest
+org.mariadb.jdbc.DistributedTransactionTest
+org.mariadb.jdbc.MariaDbBlobTest
+org.mariadb.jdbc.StoredProcedureTest
+org.mariadb.jdbc.TimezoneDaylightSavingTimeTest
+org.mariadb.jdbc.DataNTypeTest
+org.mariadb.jdbc.CatalogTest
+org.mariadb.jdbc.SslTest
+org.mariadb.jdbc.DriverTest
+org.mariadb.jdbc.GeometryTest
+org.mariadb.jdbc.ComMultiPrepareStatementTest
+org.mariadb.jdbc.ResultSetMetaDataTest
+org.mariadb.jdbc.PasswordEncodingTest
+org.mariadb.jdbc.DatatypeCompatibilityTest
+org.mariadb.jdbc.PooledConnectionTest
+org.mariadb.jdbc.ConnectionPoolTest
+org.mariadb.jdbc.ErrorMessageTest
+org.mariadb.jdbc.PreparedStatementTest
+org.mariadb.jdbc.MultiTest
+org.mariadb.jdbc.UpdateResultSetMethodsTest
+org.mariadb.jdbc.DataTypeSignedTest
+org.mariadb.jdbc.RePrepareTest
+org.mariadb.jdbc.BlobTest
+org.mariadb.jdbc.BasicBatchTest
+org.mariadb.jdbc.MariaDbPoolDataSourceTest
+org.mariadb.jdbc.DataSourceTest
+org.mariadb.jdbc.StateChangeTest
+org.mariadb.jdbc.DatabaseMetadataTest
+org.mariadb.jdbc.JdbcParserTest
+org.mariadb.jdbc.TruncateExceptionTest
+org.mariadb.jdbc.internal.protocol.tls.HostnameVerifierImplTest
+org.mariadb.jdbc.internal.util.DefaultOptionsTest
+org.mariadb.jdbc.internal.util.dao.ClientPrepareResultTest
+org.mariadb.jdbc.internal.util.UtilsTest
+org.mariadb.jdbc.internal.util.SchedulerServiceProviderHolderTest
+org.mariadb.jdbc.internal.util.buffer.BufferTest
+org.mariadb.jdbc.UtilTest
+org.mariadb.jdbc.ParserTest
+org.mariadb.jdbc.FetchSizeTest
+org.mariadb.jdbc.MariaDbDatabaseMetaDataTest
+org.mariadb.jdbc.CollationTest
+org.mariadb.jdbc.BigQueryTest
+org.mariadb.jdbc.BufferTest
+org.mariadb.jdbc.BooleanTest'
+
+initialize_db() {
+	systemctl start mariadb
+	# remove anonymous, because tests fail otherwise
+	mysql -e "DROP USER ''@'localhost'"
+	mysql -e "DROP USER ''@'$(hostname)'"
+	mysql -e "FLUSH PRIVILEGES"
+	# create database on which tests operate
+	mysql -e "CREATE DATABASE testj"
+}
+
+run_test() {
+	local JAVA_PATH=.
+	# import JUnit
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/hamcrest/core.jar
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/junit.jar
+	
+	# MariaDB
+	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client.jar
+	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client-tests.jar
+	
+	# slf4j
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-api.jar
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-simple.jar
+	# AWS
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-core.jar
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-rds.jar
+	
+	# other dependencies
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/HikariCP.jar
+	JAVA_PATH=$JAVA_PATH:/usr/lib/java/jna.jar
+
+	java -Xmx1024m -cp $JAVA_PATH org.junit.runner.JUnitCore "$1"
+}
+
+run_all() {
+	local FAILED=false
+	echo "$RUN_TESTS" | while read test; do
+		echo $test
+		run_test $test || FAILED=true
+	done
+	[ "$FAILED" == "true" ] && {
+	echo '********************************'
+	echo '************ THERE ARE FAILURES!'
+	echo '********************************'
+	return 1
+	}
+	[ "$FAILED" == "false" ] && {
+	echo '**********************************'
+	echo '************ TESTS WERE SUCCESSFUL'
+	echo '**********************************'
+	}
+}
+
+initialize_db
+run_all
+
+

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -1,90 +1,9 @@
 #!/bin/bash
 
-yum install -y mariadb-java-client mariadb-java-client-tests hamcrest junit mariadb-server
+yum install -y mariadb-java-client mariadb-java-client-tests hamcrest junit mariadb-server unzip
 
-# command to obtain all tests in Java format
-# find org -name '*Test.java' | cut -d'.' -f1 | tr '/' '.'
-RUN_TESTS='org.mariadb.jdbc.CheckDataTest
-org.mariadb.jdbc.ExecuteBatchTest
-org.mariadb.jdbc.TransactionTest
-org.mariadb.jdbc.ServerPrepareStatementTest
-org.mariadb.jdbc.DateTest
-org.mariadb.jdbc.MariaDbCompatibilityTest
-org.mariadb.jdbc.ScrollTypeTest
-org.mariadb.jdbc.StatementTest
-org.mariadb.jdbc.LocalInfileDisableTest
-org.mariadb.jdbc.GeneratedKeysTest
-org.mariadb.jdbc.failover.SequentialFailoverTest
-org.mariadb.jdbc.failover.AuroraFailoverTest
-org.mariadb.jdbc.failover.BaseMultiHostTest
-org.mariadb.jdbc.failover.LoadBalanceFailoverTest
-org.mariadb.jdbc.failover.MonoServerFailoverTest
-org.mariadb.jdbc.failover.CancelTest
-org.mariadb.jdbc.failover.ReplicationFailoverTest
-org.mariadb.jdbc.failover.OldFailoverTest
-org.mariadb.jdbc.failover.AuroraAutoDiscoveryTest
-org.mariadb.jdbc.failover.GaleraFailoverTest
-org.mariadb.jdbc.LocalInfileInputStreamTest
-org.mariadb.jdbc.ConnectionTest
-org.mariadb.jdbc.UnicodeTest
-org.mariadb.jdbc.AllowMultiQueriesTest
-org.mariadb.jdbc.UpdateResultSetTest
-org.mariadb.jdbc.ClientPreparedStatementParsingTest
-org.mariadb.jdbc.DataTypeUnsignedTest
-org.mariadb.jdbc.ResultSetUnsupportedMethodsTest
-org.mariadb.jdbc.ResultSetTest
-org.mariadb.jdbc.DatatypeTest
-org.mariadb.jdbc.GeneratedTest
-org.mariadb.jdbc.TimeoutTest
-org.mariadb.jdbc.CancelTest
-org.mariadb.jdbc.BaseTest
-org.mariadb.jdbc.GiganticLoadDataInfileTest
-org.mariadb.jdbc.DataSourcePoolTest
-org.mariadb.jdbc.MariaDbClobTest
-org.mariadb.jdbc.CallStatementTest
-org.mariadb.jdbc.DistributedTransactionTest
-org.mariadb.jdbc.MariaDbBlobTest
-org.mariadb.jdbc.StoredProcedureTest
-org.mariadb.jdbc.TimezoneDaylightSavingTimeTest
-org.mariadb.jdbc.DataNTypeTest
-org.mariadb.jdbc.CatalogTest
-org.mariadb.jdbc.SslTest
-org.mariadb.jdbc.DriverTest
-org.mariadb.jdbc.GeometryTest
-org.mariadb.jdbc.ComMultiPrepareStatementTest
-org.mariadb.jdbc.ResultSetMetaDataTest
-org.mariadb.jdbc.PasswordEncodingTest
-org.mariadb.jdbc.DatatypeCompatibilityTest
-org.mariadb.jdbc.PooledConnectionTest
-org.mariadb.jdbc.ConnectionPoolTest
-org.mariadb.jdbc.ErrorMessageTest
-org.mariadb.jdbc.PreparedStatementTest
-org.mariadb.jdbc.MultiTest
-org.mariadb.jdbc.UpdateResultSetMethodsTest
-org.mariadb.jdbc.DataTypeSignedTest
-org.mariadb.jdbc.RePrepareTest
-org.mariadb.jdbc.BlobTest
-org.mariadb.jdbc.BasicBatchTest
-org.mariadb.jdbc.MariaDbPoolDataSourceTest
-org.mariadb.jdbc.DataSourceTest
-org.mariadb.jdbc.StateChangeTest
-org.mariadb.jdbc.DatabaseMetadataTest
-org.mariadb.jdbc.JdbcParserTest
-org.mariadb.jdbc.TruncateExceptionTest
-org.mariadb.jdbc.internal.protocol.tls.HostnameVerifierImplTest
-org.mariadb.jdbc.internal.util.DefaultOptionsTest
-org.mariadb.jdbc.internal.util.dao.ClientPrepareResultTest
-org.mariadb.jdbc.internal.util.UtilsTest
-org.mariadb.jdbc.internal.util.SchedulerServiceProviderHolderTest
-org.mariadb.jdbc.internal.util.buffer.BufferTest
-org.mariadb.jdbc.UtilTest
-org.mariadb.jdbc.ParserTest
-org.mariadb.jdbc.FetchSizeTest
-org.mariadb.jdbc.MariaDbDatabaseMetaDataTest
-org.mariadb.jdbc.CollationTest
-org.mariadb.jdbc.BigQueryTest
-org.mariadb.jdbc.BufferTest
-org.mariadb.jdbc.BooleanTest'
+# list all available test classes
+MARIADB_TESTS="$(unzip -Z1 $JAVA_LIBRARY_TESTS | grep 'Test.class' | cut -d'.' -f1 | tr '/' '.' | sort)"
 
 initialize_db() {
 	systemctl start mariadb
@@ -102,8 +21,7 @@ run_test() {
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/hamcrest/core.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/junit.jar
 	# MariaDB
-	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client.jar
-	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client-tests.jar
+	JAVA_PATH=$JAVA_PATH:$JAVA_LIBRARY:$JAVA_LIBRARY_TESTS
 	# other dependencies
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-api.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-simple.jar
@@ -118,10 +36,11 @@ run_test() {
 
 run_all() {
 	local FAILED=false
+	echo "These tests will run: $MARIADB_TESTS"
 	while read -r test; do
 		echo "Run test: '$test'"
 		run_test $test || FAILED=true
-	done <<< "$RUN_TESTS"
+	done <<< "$MARIADB_TESTS"
 	[ "$FAILED" == "true" ] && {
 	echo '*********************************'
 	echo '************ TESTS HAVE FAILURES!'

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -104,15 +104,14 @@ run_test() {
 	# MariaDB
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client.jar
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client-tests.jar
-	# slf4j
+	# other dependencies
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-api.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-simple.jar
-	# AWS
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-core.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-rds.jar
-	# other dependencies
-	JAVA_PATH=$JAVA_PATH:/usr/share/java/HikariCP.jar
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/jna.jar
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/jna/jna-platform.jar
+	JAVA_PATH=$JAVA_PATH:/usr/share/java/HikariCP.jar
 
 	java -Xmx1024m -cp $JAVA_PATH org.junit.runner.JUnitCore "$1"
 }

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yum install mariadb-java-client mariadb-java-client-tests hamcrest junit mariadb-server
+yum install -y mariadb-java-client mariadb-java-client-tests hamcrest junit mariadb-server
 
 # command to obtain all tests in Java format
 # find org -name '*Test.java' | cut -d'.' -f1 | tr '/' '.'

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -119,10 +119,10 @@ run_test() {
 
 run_all() {
 	local FAILED=false
-	echo "$RUN_TESTS" | while read test; do
+	while read -r test; do
 		echo "Run test: '$test'"
 		run_test $test || FAILED=true
-	done
+	done <<< "$RUN_TESTS"
 	[ "$FAILED" == "true" ] && {
 	echo '*********************************'
 	echo '************ TESTS HAVE FAILURES!'

--- a/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
+++ b/packages/mariadb-java-client-common/upstream-tests/upstream-tests.sh
@@ -101,18 +101,15 @@ run_test() {
 	# import JUnit
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/hamcrest/core.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/junit.jar
-	
 	# MariaDB
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client.jar
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/mariadb-java-client-tests.jar
-	
 	# slf4j
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-api.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/slf4j/slf4j-simple.jar
 	# AWS
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-core.jar
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/aws-sdk-java/aws-java-sdk-rds.jar
-	
 	# other dependencies
 	JAVA_PATH=$JAVA_PATH:/usr/share/java/HikariCP.jar
 	JAVA_PATH=$JAVA_PATH:/usr/lib/java/jna.jar
@@ -123,13 +120,13 @@ run_test() {
 run_all() {
 	local FAILED=false
 	echo "$RUN_TESTS" | while read test; do
-		echo $test
+		echo "Run test: '$test'"
 		run_test $test || FAILED=true
 	done
 	[ "$FAILED" == "true" ] && {
-	echo '********************************'
-	echo '************ THERE ARE FAILURES!'
-	echo '********************************'
+	echo '*********************************'
+	echo '************ TESTS HAVE FAILURES!'
+	echo '*********************************'
 	return 1
 	}
 	[ "$FAILED" == "false" ] && {

--- a/packages/mariadb-java-client/enabled_tests
+++ b/packages/mariadb-java-client/enabled_tests
@@ -1,0 +1,3 @@
+install
+upstream-tests
+uninstall

--- a/packages/mariadb-java-client/include.sh
+++ b/packages/mariadb-java-client/include.sh
@@ -1,2 +1,4 @@
 export PACKAGE=mariadb-java-client
 export INSTALL_PKGS="mariadb-java-client mariadb-java-client-javadoc mariadb-java-client-tests"
+export JAVA_LIBRARY=/usr/lib/java/mariadb-java-client.jar
+export JAVA_LIBRARY_TESTS=/usr/lib/java/mariadb-java-client-tests.jar

--- a/packages/mariadb-java-client/include.sh
+++ b/packages/mariadb-java-client/include.sh
@@ -1,2 +1,2 @@
 export PACKAGE=mariadb-java-client
-export INSTALL_PKGS="mariadb-java-client mariadb-java-client-tests"
+export INSTALL_PKGS="mariadb-java-client mariadb-java-client-javadoc mariadb-java-client-tests"

--- a/packages/mariadb-java-client/include.sh
+++ b/packages/mariadb-java-client/include.sh
@@ -1,0 +1,2 @@
+export PACKAGE=mariadb-java-client
+export INSTALL_PKGS="mariadb-java-client mariadb-java-client-tests"

--- a/packages/mariadb-java-client/install/run.sh
+++ b/packages/mariadb-java-client/install/run.sh
@@ -1,0 +1,1 @@
+../../common-scripts/install/run.sh

--- a/packages/mariadb-java-client/run.sh
+++ b/packages/mariadb-java-client/run.sh
@@ -1,0 +1,1 @@
+../common-scripts/run.sh

--- a/packages/mariadb-java-client/uninstall/run.sh
+++ b/packages/mariadb-java-client/uninstall/run.sh
@@ -1,0 +1,1 @@
+../../common-scripts/uninstall/run.sh

--- a/packages/mariadb-java-client/upstream-tests/run.sh
+++ b/packages/mariadb-java-client/upstream-tests/run.sh
@@ -1,0 +1,1 @@
+../../mariadb-java-client-common/upstream-tests/run.sh


### PR DESCRIPTION
MariaDB provides big collection of tests for its Java connector and this PR adds logic for running these tests against installed libraries with right version of library and tests (matched in time of building in Koji).
